### PR TITLE
feat: deploy a postgres database for kinokube

### DIFF
--- a/apps/postgres-operator/base/configmap.yaml
+++ b/apps/postgres-operator/base/configmap.yaml
@@ -1,0 +1,9 @@
+---
+# Source: https://raw.githubusercontent.com/zalando/postgres-operator/6035fdd58ec1b11b5471cb4ef67eab9e6693f283/manifests/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-operator
+data:
+  debug_logging: "false"
+  inherited_labels: app.kubernetes.io/instance

--- a/apps/postgres-operator/base/kinokube.yaml
+++ b/apps/postgres-operator/base/kinokube.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
+metadata:
+  name: kinokube-psql
+  namespace: kinokube
+spec:
+  teamId: kinokube
+  volume:
+    size: 20Gi
+  numberOfInstances: 1
+  users:
+    eric:
+      - superuser
+      - createdb
+    sonarr: []
+  databases: # dbname: owner
+    sonarr-main: sonarr
+    sonarr-logs: sonarr
+  postgresql:
+    version: "17"
+    parameters:
+      password_encryption: scram-sha-256

--- a/apps/postgres-operator/base/kustomization.yaml
+++ b/apps/postgres-operator/base/kustomization.yaml
@@ -2,6 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: postgres-operator
 resources:
-  - https://github.com/zalando/postgres-operator//manifests?timeout=120&ref=6035fdd58ec1b11b5471cb4ef67eab9e6693f283 # 1.14.0
+  - ../origin/ # The raw upstream manifests
+  - kinokube.yaml # individual db cluster
+
+patches:
+  - path: configmap.yaml # global overrides for operator

--- a/apps/postgres-operator/origin/kustomization.yaml
+++ b/apps/postgres-operator/origin/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: postgres-operator
+resources:
+  - https://github.com/zalando/postgres-operator//manifests?timeout=120&ref=6035fdd58ec1b11b5471cb4ef67eab9e6693f283 # 1.14.0


### PR DESCRIPTION
also added a gentle refactor to pull the upstream manifests as a separate base. they didn't ship with a namespace so i want to set the installation of the operator in a specific namespace but the psql deployments adjacent to the applications