### PR TITLE
chore: switch to unauthn'd startup probes

### DIFF
--- a/apps/prowlarr/base/deployment.yaml
+++ b/apps/prowlarr/base/deployment.yaml
@@ -24,23 +24,11 @@ spec:
           ports:
             - containerPort: 9696
               name: webui
-          livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - curl "http://localhost:9696/prowlarr/api/v1/health?ApiKey=$(sed -ne '/ApiKey/{s/.*<ApiKey>\(.*\)<\/ApiKey>.*/\1/p;q;}' </config/config.xml)"
-            initialDelaySeconds: 30
-            periodSeconds: 60
-          readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - curl "http://localhost:9696/prowlarr/api/v1/system/status?ApiKey=$(sed -ne '/ApiKey/{s/.*<ApiKey>\(.*\)<\/ApiKey>.*/\1/p;q;}' </config/config.xml)"
-            initialDelaySeconds: 30
-            periodSeconds: 60
-            timeoutSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: webui
+            periodSeconds: 30
           volumeMounts:
             - mountPath: "/config"
               name: config

--- a/apps/radarr/base/deployment.yaml
+++ b/apps/radarr/base/deployment.yaml
@@ -24,23 +24,11 @@ spec:
           ports:
             - containerPort: 7878
               name: webui
-          livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - curl "http://localhost:7878/radarr/api/v3/health?ApiKey=$(sed -ne '/ApiKey/{s/.*<ApiKey>\(.*\)<\/ApiKey>.*/\1/p;q;}' </config/config.xml)"
-            initialDelaySeconds: 30
-            periodSeconds: 60
-          readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - curl "http://localhost:7878/radarr/api/v3/system/status?ApiKey=$(sed -ne '/ApiKey/{s/.*<ApiKey>\(.*\)<\/ApiKey>.*/\1/p;q;}' </config/config.xml)"
-            initialDelaySeconds: 30
-            periodSeconds: 60
-            timeoutSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: webui
+            periodSeconds: 30
           volumeMounts:
             - mountPath: "/config"
               name: config

--- a/apps/sonarr/base/deployment.yaml
+++ b/apps/sonarr/base/deployment.yaml
@@ -25,23 +25,12 @@ spec:
           ports:
             - containerPort: 8989
               name: webui
-          livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - curl "http://localhost:8989/sonarr/api/v3/health?ApiKey=$(sed -ne '/ApiKey/{s/.*<ApiKey>\(.*\)<\/ApiKey>.*/\1/p;q;}' </config/config.xml)"
-            initialDelaySeconds: 30
-            periodSeconds: 60
-          readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - curl "http://localhost:8989/sonarr/api/v3/system/status?ApiKey=$(sed -ne '/ApiKey/{s/.*<ApiKey>\(.*\)<\/ApiKey>.*/\1/p;q;}' </config/config.xml)"
-            initialDelaySeconds: 30
-            periodSeconds: 60
-            timeoutSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: webui
+            periodSeconds: 30
+            failureThreshold: 10
           volumeMounts:
             - mountPath: "/config"
               name: config


### PR DESCRIPTION
switches the startup probes to an unauthenticated zpage instead of trying to preconfigure api auth from the environment. this is much simpler.

future todo would be to automate tying all these together. problem for another day.