### PR TITLE
bugfix: increase udp timeout in traefik

### DIFF
--- a/apps/traefik/overlays/lab/helmchartconfig.yaml
+++ b/apps/traefik/overlays/lab/helmchartconfig.yaml
@@ -5,6 +5,8 @@ metadata:
   name: traefik
 spec:
   valuesContent: |-
+    additionalArguments:
+      - "--entryPoints.minecraft.udp.timeout=10s"
     ports:
       web:
         redirectTo:

--- a/apps/traefik/overlays/live/helmchartconfig.yaml
+++ b/apps/traefik/overlays/live/helmchartconfig.yaml
@@ -5,6 +5,8 @@ metadata:
   name: traefik
 spec:
   valuesContent: |-
+    additionalArguments:
+      - "--entryPoints.minecraft.udp.timeout=10s"
     ports:
       web:
         redirectTo:


### PR DESCRIPTION
slow tablets are slow and so traefik gives up the ghost waiting for them.